### PR TITLE
Make some `Platform` fields optional for Dell AI PCs

### DIFF
--- a/dell_ai/platforms.py
+++ b/dell_ai/platforms.py
@@ -1,6 +1,6 @@
 """Platform-related functionality for the Dell AI SDK."""
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -22,12 +22,16 @@ class Platform(BaseModel):
     vendor: str
     accelerator_type: str = Field(alias="acceleratorType")
     accelerator: str
-    gpuram: str
-    gpuinterconnect: str
+    gpuram: Optional[str] = Field(default=None)
+    gpuinterconnect: Optional[str] = Field(default=None)
     product_name: str = Field(alias="productName")
-    totalgpucount: int
-    interconnect_east_west: str = Field(alias="interonnect-east-west")
-    interconnect_north_south: str = Field(alias="interconnect-north-south")
+    totalgpucount: Optional[int] = Field(default=None)
+    interconnect_east_west: Optional[str] = Field(
+        default=None, alias="interonnect-east-west"
+    )
+    interconnect_north_south: Optional[str] = Field(
+        default=None, alias="interconnect-north-south"
+    )
 
     class Config:
         """Pydantic model configuration.

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ wheels = [
 
 [[package]]
 name = "dell-ai"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
## Description

As reported internally by Dell, this PR makes some of the `Platform` fields `Optional`, since those are indeed mandatory for Dell Platform Servers but not for Dell AI PCs, meaning that those will now default to `None` i.e. `null` in the JSON.