### PR TITLE
Update `SKILL.md` to include deploy and envs logic

### DIFF
--- a/skills/dell-ai/SKILL.md
+++ b/skills/dell-ai/SKILL.md
@@ -14,10 +14,14 @@ dell-ai interacts with the Dell Enterprise Hub (DEH) — discovering models, exp
 - User needs to check which Dell hardware platforms support a given model
 - User wants to generate Docker or Kubernetes deployment commands for a model and then run it.
 - User wants a goodput-optimized deployment snippet (balanced, long-context, high-concurrency, performance).
+- User wants to **deploy** a model or app directly onto the local node (not just generate a snippet)
+- User wants to **tear down** / undeploy a running deployment
+- User wants to **check the status** of deployed endpoints, checkpoints, and running containers/deployments
 - User wants to explore or deploy applications from the Dell app catalog
 - User needs to check system compatibility with Dell AI platforms
 - User asks about Dell AI, Dell Enterprise Hub, or DEH
 - User wants to authenticate with Dell AI using a Hugging Face token
+- User wants to manage local/global **environment variables** for dell-ai
 - User wants to check their system info or check system compatibility against Dell AI validated configs
 
 ## Installation
@@ -176,6 +180,137 @@ config = [
 snippet = client.get_app_snippet("openwebui", config)
 print(snippet)  # Helm install command
 ```
+
+## Deploying models and applications (local execution)
+
+Beyond generating snippets, dell-ai can **execute** them on the local node using
+the locally available engine: `docker` (Docker CLI), `kubernetes` (`kubectl
+apply`), or Helm (apps). The relevant tool must be installed and configured.
+
+Deployments run **detached (background) by default**. For Docker, dell-ai
+automatically:
+- converts interactive flags (`-it`) to detached (`-d`) and captures the
+  container ID and inferred endpoint URL,
+- remaps the host port to a free one if the snippet's port is already in use,
+- allocates and pins free GPU indices.
+
+On success, metadata (endpoint, engine, container/deployment ID, assigned GPUs)
+is written to the **deployment registry** (see below).
+
+Provide **either** `num_gpus` **or** `goodput` — mutually exclusive, exactly one
+required (same rule as snippet generation).
+
+```python
+# Deploy a model on the local node
+result = client.deploy_model(
+    model_id="meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    platform_id="xe9680-nvidia-h200",
+    engine="docker",              # "docker" or "kubernetes"
+    num_gpus=8,                   # or goodput="balanced" (omit num_gpus)
+    num_replicas=1,
+    detach=True,                  # False = run in foreground
+    # local_dir="/data/weights",           # mount local weights (Docker only)
+    # hf_cache_dir="~/.cache/huggingface",  # or reuse an HF cache (mutually exclusive)
+)
+# result dict: success(bool), engine, endpoint, container_id | k8s_deployment, error?
+
+# Deploy an app (Helm)
+result = client.deploy_app(app_id="openwebui", config=[...], detach=True)
+```
+
+`deploy_model` / `deploy_app` **do not raise on runtime failure** — they return
+`{"success": False, "error": ...}`. They still raise `ValidationError`,
+`ResourceNotFoundError`, or `GatedRepoAccessError` for bad parameters or access.
+
+CLI equivalents:
+
+```bash
+# Manual GPU sizing / goodput
+dell-ai models deploy -m <model_id> -p <platform_id> -e docker --gpus 8
+dell-ai models deploy -m <model_id> -p <platform_id> -e docker --goodput balanced
+
+# Kubernetes / foreground
+dell-ai models deploy -m <model_id> -p <platform_id> -e kubernetes --gpus 8
+dell-ai models deploy -m <model_id> -p <platform_id> -e docker --no-detach
+
+# Serve local weights instead of downloading (Docker only; path must exist; mutually exclusive)
+dell-ai models deploy -m <model_id> -p <platform_id> -e docker --gpus 8 --local-dir /data/weights
+dell-ai models deploy -m <model_id> -p <platform_id> -e docker --gpus 8 --hf-cache-dir ~/.cache/huggingface
+
+# App (Helm)
+dell-ai apps deploy openwebui --config '{"config":[{"helmPath":"main.config.storageClassName","type":"string","value":"gp2"}]}'
+```
+
+## Deployment registry and teardown
+
+Successful deployments are tracked in a registry so they can be listed,
+inspected, and torn down. Two scopes:
+- **Local** — `.dell-ai-deployments.json` (current working directory)
+- **Global** — `~/.config/dell-ai/deployments.json`
+
+Each entry is keyed by a **deployment ID** (defaults to the model ID; additional
+instances of the same model are suffixed, e.g. `org/model_1`, each with its own
+host port and GPU indices). Running DEH Docker containers are auto-discovered and
+added; entries whose containers are gone are pruned automatically.
+
+```python
+from dell_ai import deployments
+
+deployments.list_deployments()             # dict keyed by deployment ID
+deployments.get_deployment("org/model_1")    # single entry or None
+deployments.delete_deployment("org/model_1") # remove registry entry (no container stop)
+```
+
+Tear down a deployment — stops the Docker container / Kubernetes deployment **and**
+removes its registry entry:
+
+```bash
+dell-ai models undeploy -d <deployment_id>
+```
+
+`undeploy` acts on **one deployment at a time**. Always run
+`dell-ai status` first to see if the target deployment ID exists.
+
+## Environment variables
+
+dell-ai persists configuration as environment variables in two scopes,
+auto-loaded into `os.environ` on CLI startup and `DellAIClient` init. Resolution
+precedence: **shell env → local → global**.
+- **Local** — `.dell-ai-env.json` (current working directory)
+- **Global** — `~/.config/dell-ai/env.json`
+
+```python
+from dell_ai import env
+
+env.set_env_var("DELL_AI_CHECKPOINT", "/data/ckpt", is_global=False)
+env.get_env_var("DELL_AI_CHECKPOINT")
+env.list_env_vars()   # is_global: None=combined, True=global only, False=local only
+env.delete_env_var("DELL_AI_CHECKPOINT", is_global=False)
+```
+
+```bash
+dell-ai env set DELL_AI_CHECKPOINT /data/ckpt   # add --global for the global scope
+dell-ai env get DELL_AI_CHECKPOINT
+dell-ai env list                                # --local / --global to scope
+dell-ai env delete DELL_AI_CHECKPOINT           # --global to delete from global
+```
+
+## Checking deployment status
+
+```bash
+dell-ai status          # active deployments, checkpoints, running Docker/K8s
+dell-ai status --clean  # also remove exited containers and stopped K8s deployments
+```
+
+Reports:
+- **Active deployments** — reads the deployment registry, probes each endpoint
+  (online + response time); auto-discovers running DEH containers.
+- **Checkpoints** — existence, type, and size of paths in `DELL_AI_*_CHECKPOINT`
+  environment variables.
+- **Active Docker/K8s** — running DEH containers and Kubernetes deployments.
+
+Docker/Kubernetes scanning is skipped gracefully when `docker` / `kubectl` are
+not available on the node.
 
 ## System Utilities (CLI only, Linux)
 


### PR DESCRIPTION
## Description

This PR updates the `SKILL.md` by including new descriptions on how to deploy and undeploy models/apps, how to inspect de registry and how to work with DEH env vars. 

This comes after merging #55