### PR TITLE
Add `--image-tag` support and `models list-tags` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ dell-ai platforms list
 
 # Generate a Docker deployment snippet
 dell-ai models get-snippet --model-id meta-llama/Llama-4-Maverick-17B-128E-Instruct --platform-id xe9680-nvidia-h200 --engine docker --gpus 8 --replicas 1
+
+# List the container image tags available for a model on a platform
+dell-ai models list-tags --model-id meta-llama/Llama-4-Maverick-17B-128E-Instruct --platform-id xe9680-nvidia-h200
+
+# Pin one of those tags in the snippet
+dell-ai models get-snippet --model-id meta-llama/Llama-4-Maverick-17B-128E-Instruct --platform-id xe9680-nvidia-h200 --engine docker --gpus 8 --image-tag vllm-v0.11.2
 ```
 
 ### Using the SDK
@@ -120,9 +126,17 @@ snippet = client.get_deployment_snippet(
     platform_id="xe9680-nvidia-h200",
     engine="docker",
     num_gpus=8,
-    num_replicas=1
+    num_replicas=1,
+    image_tag="vllm-v0.11.2",  # optional; pin a specific container image tag
 )
 print(snippet)
+
+# Inspect the container image tags available for a model on a platform
+tags = client.get_container_tags(
+    model_id="meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    platform_id="xe9680-nvidia-h200",
+)
+print([tag.id for tag in tags])
 ```
 
 ## Deploying models and applications

--- a/TREE.md
+++ b/TREE.md
@@ -43,12 +43,18 @@ dell-ai
 │   │
 │   ├── check-access <model_id>           Check access to a (gated) model repository
 │   │
+│   ├── list-tags                         List container image tags for a model/platform
+│   │   ├── --model-id, -m <model_id>     Model ID (required)
+│   │   ├── --platform-id, -p <SKU>       Platform SKU ID (required)
+│   │   └── --format, -f <json|table>     Output format [json]
+│   │
 │   ├── get-snippet                       Generate a deployment snippet for a model
 │   │   ├── --model-id, -m <model_id>     Model ID (required)
 │   │   ├── --platform-id, -p <SKU>       Platform SKU ID (required)
 │   │   ├── --engine, -e <docker|kubernetes>  Deployment engine [docker]
 │   │   ├── --gpus, -g <INT>              Number of GPUs (min 1) [1]
-│   │   └── --replicas, -r <INT>          Number of replicas (min 1) [1]
+│   │   ├── --replicas, -r <INT>          Number of replicas (min 1) [1]
+│   │   └── --image-tag <TAG>             Pin a container image tag (see 'models list-tags')
 │   │
 │   └── deploy                            Deploy a model directly on the local node
 │       ├── --model-id, -m <model_id>     Model ID (required)
@@ -56,6 +62,7 @@ dell-ai
 │       ├── --engine, -e <docker|kubernetes>  Deployment engine [docker]
 │       ├── --gpus, -g <INT>              Number of GPUs (min 1) [1]
 │       ├── --replicas, -r <INT>          Number of replicas (min 1) [1]
+│       ├── --image-tag <TAG>             Pin a container image tag (see 'models list-tags')
 │       └── --detach / --no-detach        Run in background (detached) mode [detach]
 │
 ├── platforms                            Platform commands

--- a/dell_ai/cli/main.py
+++ b/dell_ai/cli/main.py
@@ -21,6 +21,7 @@ from dell_ai.cli.utils import (
     get_skills,
     print_apps_table,
     print_compatible_platforms_table,
+    print_container_tags_table,
     print_error,
     print_goodput_scenarios_table,
     print_json,
@@ -639,6 +640,56 @@ def models_compatible_platforms(
         print_error(f"Failed to get compatible platforms: {str(e)}")
 
 
+@models_app.command("list-tags")
+def models_list_tags(
+    model_id: str = typer.Option(
+        ...,
+        "--model-id",
+        "-m",
+        help="Model ID in the format 'organization/model_name'",
+    ),
+    platform_id: str = typer.Option(
+        ...,
+        "--platform-id",
+        "-p",
+        help="Platform SKU ID",
+    ),
+    output_format: str = typer.Option(
+        "json",
+        "--format",
+        "-f",
+        help="Output format: 'json' for raw JSON, 'table' for a formatted table",
+    ),
+) -> None:
+    """
+    List the container image tags available for a model on a given platform.
+
+    These are the values accepted by the '--image-tag' option of
+    'models get-snippet' and 'models deploy'. Tags are published per accelerator
+    vendor, so the list is resolved from the platform's vendor.
+
+    Example:
+        dell-ai models list-tags -m google/gemma-3-27b-it -p xe9680-nvidia-h100
+    """
+    try:
+        client = get_client()
+        tags = client.get_container_tags(model_id, platform_id)
+        if not tags:
+            print_warning(
+                f"No container tags are published for {model_id} "
+                f"on platform {platform_id}."
+            )
+            return
+        if output_format == "table":
+            print_container_tags_table(tags)
+        else:
+            print_json([tag.model_dump() for tag in tags])
+    except (ValidationError, ResourceNotFoundError) as e:
+        print_error(str(e))
+    except Exception as e:
+        print_error(f"Failed to list container tags: {str(e)}")
+
+
 @models_app.command("check-access")
 def models_check_access(model_id: str) -> None:
     """
@@ -707,6 +758,15 @@ def models_get_snippet(
             "Cannot be combined with --gpus."
         ),
     ),
+    image_tag: Optional[str] = typer.Option(
+        None,
+        "--image-tag",
+        help=(
+            "Pin a specific container image tag in the snippet (e.g. vllm-v0.11.2). "
+            "Must be one of the tags available for the model/platform "
+            "(see 'dell-ai models list-tags'). Defaults to the untagged image."
+        ),
+    ),
     local_dir: Optional[str] = typer.Option(
         None,
         "--local-dir",
@@ -746,12 +806,14 @@ def models_get_snippet(
         gpus: Number of GPUs to use (manual sizing; required unless --goodput)
         replicas: Number of replicas to deploy
         goodput: Goodput scenario to optimize the snippet for
+        image_tag: Container image tag to pin in the snippet
         local_dir: Local directory with model weights (Docker only)
         hf_cache_dir: HuggingFace cache directory (Docker only)
 
     Examples:
         dell-ai models get-snippet -m google/gemma-3-27b-it -p xe9680-nvidia-h100 -e docker --gpus 8 --replicas 1
         dell-ai models get-snippet -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --goodput balanced
+        dell-ai models get-snippet -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --gpus 8 --image-tag vllm-v0.11.2
         dell-ai models get-snippet -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --gpus 8 --local-dir /data/weights
         dell-ai models get-snippet -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --gpus 8 --hf-cache-dir ~/.cache/huggingface
     """
@@ -797,6 +859,7 @@ def models_get_snippet(
             num_gpus=gpus,
             num_replicas=replicas,
             goodput=goodput,
+            image_tag=image_tag,
         )
         if local_dir is not None:
             snippet = resources.inject_local_dir(snippet, local_dir)
@@ -865,6 +928,15 @@ def models_deploy(
         "--detach/--no-detach",
         help="Whether to run the model in background (detached) mode",
     ),
+    image_tag: Optional[str] = typer.Option(
+        None,
+        "--image-tag",
+        help=(
+            "Pin a specific container image tag before deploying (e.g. vllm-v0.11.2). "
+            "Must be one of the tags available for the model/platform "
+            "(see 'dell-ai models list-tags'). Defaults to the untagged image."
+        ),
+    ),
     local_dir: Optional[str] = typer.Option(
         None,
         "--local-dir",
@@ -897,6 +969,7 @@ def models_deploy(
     Examples:
         dell-ai models deploy -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --gpus 8
         dell-ai models deploy -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --goodput balanced
+        dell-ai models deploy -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --gpus 8 --image-tag vllm-v0.11.2
         dell-ai models deploy -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --gpus 8 --local-dir /data/weights
         dell-ai models deploy -m google/gemma-3-27b-it -p xe9680-nvidia-h100 --gpus 8 --hf-cache-dir ~/.cache/huggingface
     """
@@ -938,6 +1011,7 @@ def models_deploy(
             goodput=goodput,
             local_dir=local_dir,
             hf_cache_dir=hf_cache_dir,
+            image_tag=image_tag,
         )
         if result.get("success"):
             typer.echo("🎉 Deployment initiated successfully!")

--- a/dell_ai/cli/utils.py
+++ b/dell_ai/cli/utils.py
@@ -250,6 +250,29 @@ def print_compatible_platforms_table(results: List[Any]) -> None:
     stdout_console.print(table)
 
 
+def print_container_tags_table(tags: List[Any]) -> None:
+    """
+    Print the container image tags available for a model/platform as a table.
+
+    Args:
+        tags: List of ContainerTag objects (or dicts)
+    """
+    table = Table(title="Container Image Tags")
+    table.add_column("#", style="dim", width=4)
+    table.add_column("Tag", style="green")
+    table.add_column("Contains Weights", justify="center", style="cyan")
+
+    for i, tag in enumerate(tags, 1):
+        data = tag.model_dump() if hasattr(tag, "model_dump") else tag
+        table.add_row(
+            str(i),
+            data.get("id", ""),
+            "yes" if data.get("contains_weights") else "no",
+        )
+
+    stdout_console.print(table)
+
+
 def print_goodput_scenarios_table(reference: Any) -> None:
     """
     Print the goodput scenario definitions as a Rich table.

--- a/dell_ai/client.py
+++ b/dell_ai/client.py
@@ -17,7 +17,7 @@ from dell_ai.system_utils.system_info import SystemInfo
 if TYPE_CHECKING:
     from dell_ai.apps import App
     from dell_ai.goodput import GoodputReference
-    from dell_ai.models import Model
+    from dell_ai.models import ContainerTag, Model
     from dell_ai.platforms import Platform
 
 
@@ -378,6 +378,7 @@ class DellAIClient:
         num_gpus: Optional[int] = None,
         num_replicas: int = 1,
         goodput: Optional[str] = None,
+        image_tag: Optional[str] = None,
     ) -> str:
         """
         Get a deployment snippet for the specified model and configuration.
@@ -393,12 +394,16 @@ class DellAIClient:
             num_gpus: The number of GPUs to use (omit when using goodput)
             num_replicas: The number of replicas to deploy
             goodput: Goodput scenario to optimize for (e.g. "balanced")
+            image_tag: Container image tag to pin in the snippet (e.g.
+                "vllm-v0.11.2"). Validated against the tags available for the
+                model/platform. When omitted the image is left untagged.
 
         Returns:
             A string containing the deployment snippet (docker command or k8s manifest)
 
         Raises:
-            ValidationError: If any of the input parameters are invalid
+            ValidationError: If any of the input parameters are invalid, or the
+                requested image_tag is not available for the model/platform
             ResourceNotFoundError: If the model or platform is not found
             AuthenticationError: If authentication fails
             APIError: If the API returns an error
@@ -413,7 +418,31 @@ class DellAIClient:
             num_gpus=num_gpus,
             num_replicas=num_replicas,
             goodput=goodput,
+            image_tag=image_tag,
         )
+
+    def get_container_tags(
+        self, model_id: str, platform_id: str
+    ) -> List["ContainerTag"]:
+        """
+        Get the container image tags available for a model on a given platform.
+
+        Args:
+            model_id: The model ID in the format "organization/model_name"
+            platform_id: The platform SKU ID
+
+        Returns:
+            A list of ContainerTag objects available for the model/platform pair.
+
+        Raises:
+            ValidationError: If the model_id format is invalid
+            ResourceNotFoundError: If the model or platform is not found
+            AuthenticationError: If authentication fails
+            APIError: If the API returns an error
+        """
+        from dell_ai import models
+
+        return models.get_container_tags(self, model_id, platform_id)
 
     def get_goodput_scenarios(self) -> "GoodputReference":
         """
@@ -499,6 +528,7 @@ class DellAIClient:
         goodput: Optional[str] = None,
         local_dir: Optional[str] = None,
         hf_cache_dir: Optional[str] = None,
+        image_tag: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Deploy a model on the local node.
@@ -518,6 +548,9 @@ class DellAIClient:
             hf_cache_dir: Path to a HuggingFace cache directory. Mounts the folder
                 as the container's HF cache and sets HF_HUB_CACHE accordingly.
                 Mutually exclusive with local_dir.
+            image_tag: Container image tag to pin in the snippet (e.g.
+                "vllm-v0.11.2"). Validated against the tags available for the
+                model/platform. When omitted the image is left untagged.
 
         Returns:
             A dictionary containing deployment execution details.
@@ -540,6 +573,7 @@ class DellAIClient:
             num_gpus=num_gpus,
             num_replicas=num_replicas,
             goodput=goodput,
+            image_tag=image_tag,
         )
 
         gpu_indices: list = []

--- a/dell_ai/models.py
+++ b/dell_ai/models.py
@@ -351,6 +351,38 @@ def get_compatible_platforms(
     return results
 
 
+def get_container_tags(
+    client: "DellAIClient", model_id: str, platform_id: str
+) -> List[ContainerTag]:
+    """
+    Get the container image tags available for a model on a given platform.
+
+    Tags are published per accelerator vendor (e.g. "nvidia", "amd"), so this
+    resolves the platform's vendor and returns the tags for that vendor.
+
+    Args:
+        client: The Dell AI client
+        model_id: The model ID in the format "organization/model_name"
+        platform_id: The platform SKU ID
+
+    Returns:
+        A list of ContainerTag objects available for the model/platform pair.
+        Empty if the model publishes no tags for the platform's vendor.
+
+    Raises:
+        ValidationError: If the model_id format is invalid
+        ResourceNotFoundError: If the model or platform is not found
+        AuthenticationError: If authentication fails
+        APIError: If the API returns an error
+    """
+    from dell_ai import platforms
+
+    model = get_model(client, model_id)
+    platform = platforms.get_platform(client, platform_id)
+    # container_tags keys are lower-cased vendors; Platform.vendor is capitalized.
+    return model.configs_deploy.container_tags.get(platform.vendor.lower(), [])
+
+
 def _validate_request_schema(
     model_id, platform_id, engine, num_gpus, num_replicas, goodput=None
 ):
@@ -501,6 +533,7 @@ def get_deployment_snippet(
     num_gpus: Optional[int] = None,
     num_replicas: int = 1,
     goodput: Optional[str] = None,
+    image_tag: Optional[str] = None,
 ) -> str:
     """
     Get a deployment snippet for the specified model and configuration.
@@ -518,12 +551,17 @@ def get_deployment_snippet(
         num_replicas: The number of replicas to deploy
         goodput: Goodput scenario to optimize for (e.g. "balanced"); the server
             picks the GPU count and other optimized params
+        image_tag: Container image tag to pin in the snippet (e.g. "vllm-v0.11.2").
+            Validated against the tags available for the model/platform; the API
+            returns an untagged image, so this is applied client-side. When
+            omitted the image is left untagged (its registry default applies).
 
     Returns:
         A string containing the deployment snippet (docker command or k8s manifest)
 
     Raises:
-        ValidationError: If any of the input parameters are invalid
+        ValidationError: If any of the input parameters are invalid, or the
+            requested image_tag is not available for the model/platform
         ResourceNotFoundError: If the model, platform, or configuration is not found
         GatedRepoAccessError: If the model repository is gated and the user doesn't have access
     """
@@ -570,4 +608,36 @@ def get_deployment_snippet(
         if goodput is not None:
             raise
         _handle_resource_not_found(client, e, model_id, platform_id, num_gpus)
-    return SnippetResponse(snippet=response.get("snippet", "")).snippet
+    snippet = SnippetResponse(snippet=response.get("snippet", "")).snippet
+
+    # Step 7: Pin the requested image tag (the API returns an untagged image).
+    if image_tag is not None:
+        snippet = _apply_image_tag(client, snippet, model_id, platform_id, image_tag)
+
+    return snippet
+
+
+def _apply_image_tag(
+    client: "DellAIClient",
+    snippet: str,
+    model_id: str,
+    platform_id: str,
+    image_tag: str,
+) -> str:
+    """Validate ``image_tag`` against available tags and inject it into the snippet."""
+    from dell_ai import resources
+
+    available = get_container_tags(client, model_id, platform_id)
+    available_ids = [tag.id for tag in available]
+    if image_tag not in available_ids:
+        if available_ids:
+            detail = f"Available tags: {', '.join(available_ids)}"
+        else:
+            detail = "No container tags are published for this model/platform."
+        raise ValidationError(
+            f"Image tag '{image_tag}' is not available for model {model_id} "
+            f"on platform {platform_id}. {detail}",
+            parameter="image_tag",
+            valid_values=available_ids,
+        )
+    return resources.inject_image_tag(snippet, image_tag)

--- a/dell_ai/resources.py
+++ b/dell_ai/resources.py
@@ -319,6 +319,33 @@ def inject_host_port(snippet: str, port: int) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Container image tag injection
+# ---------------------------------------------------------------------------
+
+# Matches the DEH image reference and stops at whitespace or quotes, so it works
+# for bare Docker image args and quoted/unquoted Kubernetes manifest values alike.
+_DEH_IMAGE_RE = re.compile(r"registry\.dell\.huggingface\.co/[^\s\"']+")
+
+
+def inject_image_tag(snippet: str, tag: str) -> str:
+    """Set the tag on every DEH container image reference in the snippet.
+
+    The Dell Enterprise Hub image (``registry.dell.huggingface.co/...``) is
+    returned untagged by the API. This appends ``:tag``, replacing an existing
+    tag if one is present. Works for both Docker commands and Kubernetes
+    manifests, and updates every occurrence so all references stay consistent.
+    """
+
+    def _set_tag(match: "re.Match[str]") -> str:
+        image = match.group(0)
+        # The registry host carries no port, so any ':' present is an existing tag.
+        base = image.split(":", 1)[0]
+        return f"{base}:{tag}"
+
+    return _DEH_IMAGE_RE.sub(_set_tag, snippet)
+
+
+# ---------------------------------------------------------------------------
 # Local weights / HF cache injection
 # ---------------------------------------------------------------------------
 

--- a/skills/dell-ai/SKILL.md
+++ b/skills/dell-ai/SKILL.md
@@ -111,12 +111,38 @@ snippet = client.get_deployment_snippet(
     platform_id="xe9680-nvidia-h200",
     engine="docker",
     goodput="balanced",    # balanced | long-context | high-concurrency | performance
+    image_tag="vllm-v0.11.2",  # optional; pin a specific container image tag
 )
 ```
 
 Not every (model, platform, scenario) combination has an optimized config; the
 API is the source of truth and raises `ResourceNotFoundError` with a message
 like `No optimized config for "balanced" scenario on this SKU.` when it doesn't.
+
+### Container image tags
+
+The API returns an **untagged** image reference. Pass `image_tag` to
+`get_deployment_snippet` / `deploy_model` to pin a specific tag; it is validated
+against the tags published for the platform's accelerator vendor, and
+`ValidationError` (with `valid_values`) is raised for an unknown tag. Discover
+the valid tags first:
+
+```python
+tags = client.get_container_tags(
+    model_id="meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    platform_id="xe9680-nvidia-h200",
+)
+# Returns List[ContainerTag] (fields: id, contains_weights) for the platform's
+# vendor; empty list if none are published. `contains_weights` marks images that
+# already bundle the model weights.
+print([t.id for t in tags])
+```
+
+```bash
+# List the tags accepted by --image-tag, then pin one
+dell-ai models list-tags -m <model_id> -p <platform_id>
+dell-ai models get-snippet -m <model_id> -p <platform_id> -e docker --gpus 8 --image-tag vllm-v0.11.2
+```
 
 ### Goodput scenarios reference data
 
@@ -209,6 +235,7 @@ result = client.deploy_model(
     num_gpus=8,                   # or goodput="balanced" (omit num_gpus)
     num_replicas=1,
     detach=True,                  # False = run in foreground
+    # image_tag="vllm-v0.11.2",            # pin a container image tag (see get_container_tags)
     # local_dir="/data/weights",           # mount local weights (Docker only)
     # hf_cache_dir="~/.cache/huggingface",  # or reuse an HF cache (mutually exclusive)
 )
@@ -232,6 +259,9 @@ dell-ai models deploy -m <model_id> -p <platform_id> -e docker --goodput balance
 # Kubernetes / foreground
 dell-ai models deploy -m <model_id> -p <platform_id> -e kubernetes --gpus 8
 dell-ai models deploy -m <model_id> -p <platform_id> -e docker --no-detach
+
+# Pin a specific container image tag (see 'dell-ai models list-tags')
+dell-ai models deploy -m <model_id> -p <platform_id> -e docker --gpus 8 --image-tag vllm-v0.11.2
 
 # Serve local weights instead of downloading (Docker only; path must exist; mutually exclusive)
 dell-ai models deploy -m <model_id> -p <platform_id> -e docker --gpus 8 --local-dir /data/weights

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -496,7 +496,59 @@ def test_models_get_snippet_success(mock_get_client, runner):
         num_gpus=1,
         num_replicas=1,
         goodput=None,
+        image_tag=None,
     )
+
+
+@patch("dell_ai.cli.main.get_client")
+def test_models_list_tags_success(mock_get_client, runner):
+    """The list-tags command prints the tags returned by the client."""
+    tag = MagicMock()
+    tag.model_dump.return_value = {"id": "vllm-v0.11.2", "contains_weights": True}
+    mock_client = Mock()
+    mock_client.get_container_tags.return_value = [tag]
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "list-tags",
+            "--model-id",
+            "google/gemma-3-27b-it",
+            "--platform-id",
+            "xe9680-nvidia-h100",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "vllm-v0.11.2" in result.output
+    mock_client.get_container_tags.assert_called_once_with(
+        "google/gemma-3-27b-it", "xe9680-nvidia-h100"
+    )
+
+
+@patch("dell_ai.cli.main.get_client")
+def test_models_list_tags_empty(mock_get_client, runner):
+    """When no tags are published the command warns instead of printing an empty list."""
+    mock_client = Mock()
+    mock_client.get_container_tags.return_value = []
+    mock_get_client.return_value = mock_client
+
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "list-tags",
+            "--model-id",
+            "google/gemma-3-27b-it",
+            "--platform-id",
+            "xe9680-nvidia-h100",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "No container tags" in result.output
 
 
 @patch("dell_ai.cli.main.get_client")
@@ -986,6 +1038,7 @@ def test_models_get_snippet_goodput(mock_get_client, runner):
         num_gpus=None,
         num_replicas=1,
         goodput="balanced",
+        image_tag=None,
     )
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -338,6 +338,7 @@ class TestDellAIClient:
                 num_gpus=1,
                 num_replicas=1,
                 goodput=None,
+                image_tag=None,
             )
 
     def test_list_apps(self):

--- a/tests/unit/test_model_snippets.py
+++ b/tests/unit/test_model_snippets.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from dell_ai import constants
+from dell_ai import constants, resources
 from dell_ai.exceptions import (
     DellAIError,
     GatedRepoAccessError,
@@ -386,6 +386,127 @@ def test_get_deployment_snippet_goodput(mock_client):
 
     # Access is still checked.
     mock_client.check_model_access.assert_called_once_with("google/gemma-3-27b-it")
+
+
+# Model/platform fixtures for the --image-tag path. The nvidia vendor publishes
+# two tags; the platform's vendor ("Nvidia") resolves to the "nvidia" tag list.
+_TAGGED_MODEL = {
+    "repoName": "google/gemma-3-27b-it",
+    "configsDeploy": {
+        "containerTags": {
+            "nvidia": [
+                {"id": "latest", "containsWeights": False},
+                {"id": "vllm-v0.11.2", "containsWeights": True},
+            ],
+            "amd": [{"id": "latest", "containsWeights": False}],
+        },
+        "configPerSku": {
+            "xe9680-nvidia-h100": [{"num_gpus": 8}],
+        },
+    },
+}
+_NVIDIA_PLATFORM = {
+    "id": "xe9680-nvidia-h100",
+    "name": "XE9680 Nvidia H100",
+    "disabled": False,
+    "platformType": "server",
+    "platform": "xe9680",
+    "vendor": "Nvidia",
+    "acceleratorType": "GPU",
+    "accelerator": "h100",
+    "productName": "NVIDIA-H100-80GB-HBM3",
+}
+_TAGGED_SNIPPET = (
+    "docker run -it --gpus 8 "
+    "registry.dell.huggingface.co/enterprise-dell-inference-google-gemma-3-27b-it"
+)
+
+
+def test_get_deployment_snippet_with_image_tag(mock_client):
+    """A valid --image-tag is validated and pinned onto the snippet's image."""
+    # Requests, in order: get_model (validation) -> snippet -> get_platform.
+    # The second get_model (inside tag resolution) is served from the cache.
+    mock_client._make_request.side_effect = [
+        _TAGGED_MODEL,
+        {"snippet": _TAGGED_SNIPPET, "engine": "docker"},
+        _NVIDIA_PLATFORM,
+    ]
+
+    result = get_deployment_snippet(
+        client=mock_client,
+        model_id="google/gemma-3-27b-it",
+        platform_id="xe9680-nvidia-h100",
+        engine="docker",
+        num_gpus=8,
+        num_replicas=1,
+        image_tag="vllm-v0.11.2",
+    )
+
+    assert result.endswith(
+        "enterprise-dell-inference-google-gemma-3-27b-it:vllm-v0.11.2"
+    )
+    assert mock_client._make_request.call_count == 3
+
+
+def test_get_deployment_snippet_invalid_image_tag(mock_client):
+    """An --image-tag not published for the platform's vendor is rejected."""
+    mock_client._make_request.side_effect = [
+        _TAGGED_MODEL,
+        {"snippet": _TAGGED_SNIPPET, "engine": "docker"},
+        _NVIDIA_PLATFORM,
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        get_deployment_snippet(
+            client=mock_client,
+            model_id="google/gemma-3-27b-it",
+            platform_id="xe9680-nvidia-h100",
+            engine="docker",
+            num_gpus=8,
+            num_replicas=1,
+            image_tag="does-not-exist",
+        )
+
+    message = str(exc_info.value)
+    assert "does-not-exist" in message
+    # The error lists the tags actually available for the vendor.
+    assert "vllm-v0.11.2" in message
+    assert "latest" in message
+
+
+def test_inject_image_tag_appends_to_untagged_docker_image():
+    """A bare Docker image reference gets the tag appended."""
+    snippet = "docker run -it registry.dell.huggingface.co/enterprise-foo"
+    result = resources.inject_image_tag(snippet, "vllm-v0.11.2")
+    assert result == (
+        "docker run -it registry.dell.huggingface.co/enterprise-foo:vllm-v0.11.2"
+    )
+
+
+def test_inject_image_tag_replaces_existing_tag():
+    """An existing tag is replaced rather than duplicated."""
+    snippet = "    image: registry.dell.huggingface.co/enterprise-foo:latest"
+    result = resources.inject_image_tag(snippet, "amd-v1")
+    assert result == "    image: registry.dell.huggingface.co/enterprise-foo:amd-v1"
+
+
+def test_inject_image_tag_preserves_quotes_in_k8s():
+    """Quoted Kubernetes image values keep their surrounding quotes."""
+    snippet = '    image: "registry.dell.huggingface.co/enterprise-foo"'
+    result = resources.inject_image_tag(snippet, "nvidia-v2")
+    assert (
+        result == '    image: "registry.dell.huggingface.co/enterprise-foo:nvidia-v2"'
+    )
+
+
+def test_inject_image_tag_updates_all_occurrences():
+    """Every image reference in a manifest is updated so they stay consistent."""
+    snippet = (
+        "image: registry.dell.huggingface.co/enterprise-foo\n"
+        "initImage: registry.dell.huggingface.co/enterprise-foo"
+    )
+    result = resources.inject_image_tag(snippet, "v3")
+    assert result.count("enterprise-foo:v3") == 2
 
 
 def test_get_deployment_snippet_goodput_unavailable(mock_client):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -7,10 +7,12 @@ import pytest
 from dell_ai import constants
 from dell_ai.exceptions import ResourceNotFoundError, ValidationError
 from dell_ai.models import (
+    ContainerTag,
     Model,
     ModelConfig,
     PlatformCompatibility,
     get_compatible_platforms,
+    get_container_tags,
     get_model,
     list_models,
     search_models,
@@ -399,3 +401,41 @@ def test_get_compatible_platforms_invalid_model_id(mock_client):
     """Test compatible platforms with an invalid model ID format."""
     with pytest.raises(ValidationError):
         get_compatible_platforms(mock_client, "invalid-model-id")
+
+
+_MOCK_PLATFORM = {
+    "id": "xe9680-nvidia-h100",
+    "name": "XE9680 Nvidia H100",
+    "disabled": False,
+    "platformType": "server",
+    "platform": "xe9680",
+    "vendor": "Nvidia",
+    "acceleratorType": "GPU",
+    "accelerator": "h100",
+    "productName": "NVIDIA-H100-80GB-HBM3",
+}
+
+
+def test_get_container_tags_resolves_platform_vendor(mock_client):
+    """Tags are resolved via the platform's (case-insensitive) vendor."""
+    # First request returns the model (and caches it); second returns the platform.
+    mock_client._make_request.side_effect = [MOCK_MODEL_DETAILS, _MOCK_PLATFORM]
+
+    tags = get_container_tags(
+        mock_client, "google/gemma-3-27b-it", "xe9680-nvidia-h100"
+    )
+
+    assert all(isinstance(t, ContainerTag) for t in tags)
+    assert [t.id for t in tags] == ["latest"]
+
+
+def test_get_container_tags_unknown_vendor_returns_empty(mock_client):
+    """A vendor with no published tags yields an empty list, not an error."""
+    intel_platform = {**_MOCK_PLATFORM, "vendor": "Intel"}
+    mock_client._make_request.side_effect = [MOCK_MODEL_DETAILS, intel_platform]
+
+    tags = get_container_tags(
+        mock_client, "google/gemma-3-27b-it", "xe9680-nvidia-h100"
+    )
+
+    assert tags == []


### PR DESCRIPTION
## Description

Lets users pin a specific container image tag when generating deployment snippets or deploying a model, and adds a first-class way to discover which tags are valid for a given model/platform. The Dell Enterprise Hub API returns an untagged image reference; this PR applies a validated tag client-side and closes the loop with a discovery command so users never have to guess valid values.

### What's included
#### Tag selection

- New `image_tag` parameter on `get_deployment_snippet` and deploy_model (SDK + CLI --image-tag).
- The tag is validated against the tags published for the platform's accelerator vendor; an unknown tag raises `ValidationError` listing the available tags (and populating valid_values).
- `inject_image_tag` (in resources.py) sets the tag on every registry.dell.huggingface.co/... reference, handling bare Docker image args and quoted/unquoted Kubernetes manifest values, and replacing an existing tag rather than duplicating it.

#### Tag discovery

- New `client.get_container_tags(model_id, platform_id) → List[ContainerTag] (fields id, contains_weights)`, resolved via the platform's vendor (case-insensitive); returns [] when none are published.
- New `dell-ai models list-tags -m <model> -p <platform>` CLI command with `--format json|table`, which surfaces exactly the values `--image-tag` accepts. Prints a clear warning instead of an empty list when no tags exist.

#### Docs

README: discover-then-pin flow for both CLI and SDK.
TREE.md: new list-tags command and corrected `--image-tag` pointers.
skills/dell-ai/SKILL.md: new "Container image tags" subsection plus image_tag in the snippet/deploy examples.